### PR TITLE
add exhaustive default arm to Reorder switch (CS8509)

### DIFF
--- a/ArmatSoftware.Code.Engine.Storage/StoredSubjectActions.cs
+++ b/ArmatSoftware.Code.Engine.Storage/StoredSubjectActions.cs
@@ -44,6 +44,7 @@ public class StoredSubjectActions<TSubject> : IStoredSubjectActions<TSubject>
                 a.Order >= order && a.Order < action.Order), // action order in decreased (moved up the list)
             1 => new Func<IStoredSubjectAction<TSubject>, bool>(a =>
                 a.Order <= order && a.Order > action.Order), // action order in increased (moved down the list)
+            _ => throw new InvalidOperationException($"Unexpected reorder direction: {directionOfReorder}"),
         };
             
         var actionsBetween = this.Where(a => shouldBeMoved(a)).ToList();


### PR DESCRIPTION
Math.Sign can return 0, which the switch did not handle. The early-return guard above prevents 0 in practice, but without a default arm the compiler cannot prove this and future callers of the method could reach an unhandled SwitchExpressionException at runtime.