### PR TITLE
add new keyword to StoredRevisionList shadow methods (CS0108)

### DIFF
--- a/ArmatSoftware.Code.Engine.Storage/StoredRevisionList.cs
+++ b/ArmatSoftware.Code.Engine.Storage/StoredRevisionList.cs
@@ -36,16 +36,16 @@ public class StoredRevisionList<TSubject> : List<StoredActionRevision>
         if (revision.Active) throw new ArgumentException("Revision cannot be active when created");
     }
 
-    public void Add(StoredActionRevision revision)
+    public new void Add(StoredActionRevision revision)
     {
         Validate(revision);
         revision.TamperProof();
         base.Add(revision);
     }
-    
-    public void Remove(StoredActionRevision revision) => throw new InvalidOperationException("Cannot remove a revision directly from a stored subject action");
-    
-    public void Clear() => throw new InvalidOperationException("Cannot clear revisions directly from a stored subject action");
+
+    public new void Remove(StoredActionRevision revision) => throw new InvalidOperationException("Cannot remove a revision directly from a stored subject action");
+
+    public new void Clear() => throw new InvalidOperationException("Cannot clear revisions directly from a stored subject action");
 
     public new void AddRange(IEnumerable<StoredActionRevision> collection)
     {
@@ -57,24 +57,24 @@ public class StoredRevisionList<TSubject> : List<StoredActionRevision>
         }
     }
 
-    public void Insert(int index, StoredActionRevision revision)
+    public new void Insert(int index, StoredActionRevision revision)
     {
         Validate(revision);
         revision.TamperProof();
         base.Insert(index, revision);
     }
 
-    public void InsertRange(int index, IEnumerable<StoredActionRevision> collection)
+    public new void InsertRange(int index, IEnumerable<StoredActionRevision> collection)
     {
         foreach (var revision in collection)
         {
             Validate(revision);
             revision.TamperProof();
             Insert(index++, revision);
-        } 
+        }
     }
-    
-    public void RemoveAt(int index) => throw new InvalidOperationException("Cannot remove a revision directly from a stored subject action");
-    
-    public void RemoveAll(Predicate<StoredActionRevision> match) => throw new InvalidOperationException("Cannot remove a revision directly from a stored subject action");
+
+    public new void RemoveAt(int index) => throw new InvalidOperationException("Cannot remove a revision directly from a stored subject action");
+
+    public new void RemoveAll(Predicate<StoredActionRevision> match) => throw new InvalidOperationException("Cannot remove a revision directly from a stored subject action");
 }


### PR DESCRIPTION
Without new, callers holding a List<StoredActionRevision> reference bypass all validation and tamper-proofing silently, going straight to the base class. Applies new to Add, Remove, Clear, Insert, InsertRange, RemoveAt, RemoveAll to make the intentional hiding explicit and consistent with AddRange.