### PR TITLE
initialize FileStorageOptions properties to suppress CS8618

### DIFF
--- a/ArmatSoftware.Code.Engine.Storage.File/FileStorageOptions.cs
+++ b/ArmatSoftware.Code.Engine.Storage.File/FileStorageOptions.cs
@@ -5,10 +5,10 @@ public class FileStorageOptions
     /// <summary>
     /// Root path of the storage location
     /// </summary>
-    public string StoragePath { get; set; }
-    
+    public string StoragePath { get; set; } = string.Empty;
+
     /// <summary>
     /// File extension of the code files
     /// </summary>
-    public string FileExtension { get; set; }
+    public string FileExtension { get; set; } = string.Empty;
 }


### PR DESCRIPTION
StoragePath and FileExtension were declared non-nullable with no initializer, causing CS8618 under nullable reference type analysis. Initializing to string.Empty preserves the existing non-nullable contract without breaking options-pattern construction via configuration binding.